### PR TITLE
chore: fix hai surplus auction events

### DIFF
--- a/src/mappings/modules/auctions/debt-auction-house.ts
+++ b/src/mappings/modules/auctions/debt-auction-house.ts
@@ -24,7 +24,7 @@ export function handleModifyParameters(event: ModifyParameters): void {
     dataSource.address(),
     enums.EnglishAuctionType_DEBT,
   )
-  let val = toUnsignedInt(event.params._data, false)
+  let val = toUnsignedInt(event.params._data)
 
   if (what == 'bidIncrease') {
     config.bidIncrease = decimal.fromWad(val)

--- a/src/mappings/modules/auctions/surplus-auction-houses.ts
+++ b/src/mappings/modules/auctions/surplus-auction-houses.ts
@@ -23,7 +23,7 @@ export function handleModifyParameters(event: ModifyParameters): void {
     dataSource.address(),
     enums.EnglishAuctionType_SURPLUS,
   )
-  let data = toUnsignedInt(event.params._data, false)
+  let data = toUnsignedInt(event.params._data)
   modifyParameter(config, event.params._param.toString(), data)
 }
 

--- a/src/mappings/modules/auctions/surplus-auction-houses.ts
+++ b/src/mappings/modules/auctions/surplus-auction-houses.ts
@@ -43,7 +43,8 @@ function modifyParameter(config: EnglishAuctionConfiguration, what: string, val:
 export function handleIncreaseBidSize(event: IncreaseBidSize): void {
   increaseBidSize(
     event.params._id,
-    decimal.fromWad(event.params._soldAmount),
+    decimal.fromRad(event.params._soldAmount),
+    decimal.fromWad(event.params._raisedAmount),
     event.params._bidder,
     event.params._bidExpiry,
     event,
@@ -53,6 +54,7 @@ export function handleIncreaseBidSize(event: IncreaseBidSize): void {
 function increaseBidSize(
   id: BigInt,
   bidAmount: BigDecimal,
+  raiseAmount: BigDecimal,
   highBidder: Bytes,
   bidExpiry: BigInt,
   event: ethereum.Event,
@@ -64,8 +66,8 @@ function increaseBidSize(
     bid.bidNumber = auction.numberOfBids
     bid.type = enums.EnglishBidType_INCREASE_BUY
     bid.auction = auction.id
-    bid.sellAmount = auction.sellInitialAmount
-    bid.buyAmount = bidAmount
+    bid.sellAmount = bidAmount
+    bid.buyAmount = raiseAmount
     bid.price = bid.sellAmount.div(bid.buyAmount)
     bid.bidder = highBidder
     bid.createdAt = event.block.timestamp

--- a/src/mappings/modules/auctions/surplus-auction-houses.ts
+++ b/src/mappings/modules/auctions/surplus-auction-houses.ts
@@ -53,7 +53,7 @@ export function handleIncreaseBidSize(event: IncreaseBidSize): void {
 
 function increaseBidSize(
   id: BigInt,
-  bidAmount: BigDecimal,
+  soldAmount: BigDecimal,
   raiseAmount: BigDecimal,
   highBidder: Bytes,
   bidExpiry: BigInt,
@@ -66,7 +66,7 @@ function increaseBidSize(
     bid.bidNumber = auction.numberOfBids
     bid.type = enums.EnglishBidType_INCREASE_BUY
     bid.auction = auction.id
-    bid.sellAmount = bidAmount
+    bid.sellAmount = soldAmount
     bid.buyAmount = raiseAmount
     bid.price = bid.sellAmount.div(bid.buyAmount)
     bid.bidder = highBidder


### PR DESCRIPTION
Te hai surplus auction house contract changed the events emitted in IncreaseBidSize, so the sellAmount/buyAmount values were flipped and also had the wrong base.